### PR TITLE
preInstallConfig.job ReadOnly fix

### DIFF
--- a/helm_charts/vault/templates/consul.preInstall.job.yaml
+++ b/helm_charts/vault/templates/consul.preInstall.job.yaml
@@ -26,6 +26,15 @@ spec:
         app: {{ template "name" . }}
     spec:
       restartPolicy: Never
+      initContainers:
+        - name: copy-ro-scripts
+          image: busybox
+          command: ['sh', '-c', 'cp /scripts/* /etc/pre-install/']
+          volumeMounts:
+            - name: scripts
+              mountPath: /scripts
+            - name: pre-install
+              mountPath: /etc/pre-install
       containers:
       - name: {{ template "fullname" . }}-{{.Values.Consul.PreInstall.ComponentName}}
         image: "{{.Values.Misc.kubectl.Image}}:{{.Values.Misc.kubectl.ImageTag}}"
@@ -64,6 +73,8 @@ spec:
           readOnly: true
       volumes:
         - name: pre-install
+          emptyDir: {}
+        - name: scripts
           configMap:
             name: {{ template "fullname" . }}-{{.Values.Consul.PreInstall.ComponentName}}
         - name: podinfo


### PR DESCRIPTION
a small fix which copies the files into an emptyDir which isn't RO

fixes #42 

PR which changed Kubernete's behavior to RO
https://github.com/kubernetes/kubernetes/pull/58720
