### PR TITLE
PodDisruptionBudget, podAntiAffinity, podManagementPolicy, livenessProbe, readinessProbe, ImageTag and No TLS verif. skipping

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ It isn't hard to [get started](https://www.vaultproject.io/intro/getting-started
 | `Consul.ImagePullPolicy` | Consul container pull policy | `IfNotPresent` |
 | `Consul.Memory` | Consul container requested memory | `256Mi` |
 | `Consul.Replicas` | Consul container replicas | `5` |
+| `Consul.maxUnavailable` | Consul container PodDisruptionBudget maxUnavailable instances | `2` |
+| `Consul.updatePartition` | Consul container updatePartition number for Phased Roll Outs | `0` |
 | `Consul.HttpPort` | Consul http listening port | `8500` |
 | `Consul.SerflanPort` | Consul serf lan listening port | `8301` |
 | `Consul.SerflanUdpPort` | Consul serf lan UDP listening port | `8301` |
@@ -84,6 +86,10 @@ It isn't hard to [get started](https://www.vaultproject.io/intro/getting-started
 | `Vault.ImagePullPolicy` | Vault container pull policy | `IfNotPresent`
 | `Vault.LogLevel` | Set vault log level (trace, debug, info, etc.) | `info` |
 | `Vault.Replicas` | Vault container replicas | `3` |
+| `Vault.maxUnavailable` | Vault container PodDisruptionBudget maxUnavailable instances | `1` |
+| `Vault.Readiness.readyIfStandby` | Mark Vault pods as ready to start accepting traffic when `Standby` status is reached | `true` |
+| `Vault.Readiness.readyIfSealed` | Mark Vault pods as ready to start accepting traffic when `Sealed` status is reached | `false` |
+| `Vault.Readiness.readyIfUninitialized` | Mark Vault pods as ready to start accepting traffic when `Uninitialized` status is reached | `true` |
 | `Vault.Cpu` | Vault container requested cpu | `512m` |
 | `Vault.Memory` | Vault container requested memory | `200Mi` |
 | `Vault.HostAliases` | List of hostfile entries, see [docs](https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/) for details and format |  |

--- a/helm_charts/vault/Chart.yaml
+++ b/helm_charts/vault/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Hashicorp Vault chart for Kubernetes
 name: vault
-version: 0.1.1
+version: 0.2.0
 keywords: [hashicorp, vault, secret, consul]
 icon: https://raw.githubusercontent.com/docker-library/docs/726714ced14b1e14b6dd99fc82f20f14f1d3cfb1/vault/logo.png
 sources:
@@ -12,8 +12,13 @@ sources:
   - https://github.com/bartlettc/omgwtfssl-kubernetes
   - https://github.com/bartlettc/letsencrypt-acm:kubernetes
   - https://github.com/thorix/consul-backup
+  - https://github.com/helm/charts/tree/master/incubator/vault
+  - https://github.com/hashicorp/consul-helm
 maintainers:
   - name: Ryan Wilcox
     email: ryan.wilcox@readytalk.com
   - name: Chris Bartlett
     email: christopher.bartlett@readytalk.com
+contributors:
+  - name: Miroslav E. Hadzhiev
+    email: miroslav.hadzhiev@gmail.com

--- a/helm_charts/vault/templates/NOTES.txt
+++ b/helm_charts/vault/templates/NOTES.txt
@@ -3,7 +3,7 @@ Vault has been installed/upgraded.
 It may take several minutes for all of the components to become available.
 
 If this is a new install, initialize Vault by running the following:
-  kubectl exec -it $(kubectl --namespace {{ .Release.Namespace }} get pods -o jsonpath="{.items[0].metadata.name}" -l "component={{ .Release.Name }}-{{ .Values.Vault.ComponentName }}") -c {{ template "vault.fullname" . }} --namespace vault sh
+  kubectl exec -it $(kubectl --namespace {{ .Release.Namespace }} get pods -o jsonpath="{.items[0].metadata.name}" -l "component={{ .Release.Name }}-{{ .Values.Vault.ComponentName }}") -c {{ template "vault.fullname" . }} --namespace {{ .Release.Namespace }} sh
   vault operator init
 
 To unseal Vault, execute into each running pod and execute:

--- a/helm_charts/vault/templates/NOTES.txt
+++ b/helm_charts/vault/templates/NOTES.txt
@@ -4,7 +4,7 @@ It may take several minutes for all of the components to become available.
 
 If this is a new install, initialize Vault by running the following:
   kubectl exec -it $(kubectl --namespace {{ .Release.Namespace }} get pods -o jsonpath="{.items[0].metadata.name}" -l "component={{ .Release.Name }}-{{ .Values.Vault.ComponentName }}") -c {{ template "vault.fullname" . }} --namespace {{ .Release.Namespace }} sh
-  vault operator init
+  vault operator init {{ template "tls_skip_verify" . }}
 
 To unseal Vault, execute into each running pod and execute:
   vault operator unseal

--- a/helm_charts/vault/templates/NOTES.txt
+++ b/helm_charts/vault/templates/NOTES.txt
@@ -3,8 +3,8 @@ Vault has been installed/upgraded.
 It may take several minutes for all of the components to become available.
 
 If this is a new install, initialize Vault by running the following:
-  kubectl exec -it $(kubectl --namespace {{ .Release.Namespace }} get pods -o jsonpath="{.items[0].metadata.name}" -l "component={{ .Release.Name }}-{{ .Values.Vault.ComponentName }}") -c {{ template "vault.fullname" . }} sh
-  vault init {{ template "tls_skip_verify" . }}
+  kubectl exec -it $(kubectl --namespace {{ .Release.Namespace }} get pods -o jsonpath="{.items[0].metadata.name}" -l "component={{ .Release.Name }}-{{ .Values.Vault.ComponentName }}") -c {{ template "vault.fullname" . }} --namespace vault sh
+  vault operator init
 
 To unseal Vault, execute into each running pod and execute:
-  vault unseal {{ template "tls_skip_verify" . }}
+  vault operator unseal

--- a/helm_charts/vault/templates/_helpers.tpl
+++ b/helm_charts/vault/templates/_helpers.tpl
@@ -45,3 +45,45 @@ This is used to skip verification when using self-signed certs or the LetsEncryp
     {{- print "" -}}
   {{ end }}
 {{- end -}}
+
+{{/*
+Compute the maximum number of unavailable Vault replicas for the PodDisruptionBudget.
+This defaults to (n/2)-1 where n is the number of members of the server cluster.
+Special case of replica equaling 3 and allowing a minor disruption of 1 otherwise
+use the integer value
+Add a special case for replicas=1, where it should default to 0 as well.
+*/}}
+{{- define "vault.pdb.maxUnavailable" -}}
+{{- if eq (int .Values.Vault.Replicas) 1 -}}
+{{ 0 }}
+{{- else if .Values.Vault.maxUnavailable -}}
+{{ .Values.Vault.maxUnavailable -}}
+{{- else -}}
+{{- if eq (int .Values.Vault.Replicas) 3 -}}
+{{- 1 -}}
+{{- else -}}
+{{- sub (div (int .Values.Vault.Replicas) 2) 1 -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Compute the maximum number of unavailable Consul replicas for the PodDisruptionBudget.
+This defaults to (n/2)-1 where n is the number of members of the server cluster.
+Special case of replica equaling 3 and allowing a minor disruption of 1 otherwise
+use the integer value
+Add a special case for replicas=1, where it should default to 0 as well.
+*/}}
+{{- define "consul.pdb.maxUnavailable" -}}
+{{- if eq (int .Values.Consul.Replicas) 1 -}}
+{{ 0 }}
+{{- else if .Values.Consul.maxUnavailable -}}
+{{ .Values.Consul.maxUnavailable -}}
+{{- else -}}
+{{- if eq (int .Values.Consul.Replicas) 3 -}}
+{{- 1 -}}
+{{- else -}}
+{{- sub (div (int .Values.Consul.Replicas) 2) 1 -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/helm_charts/vault/templates/consul.pdb.yaml
+++ b/helm_charts/vault/templates/consul.pdb.yaml
@@ -1,35 +1,22 @@
-# apiVersion: policy/v1beta1
-# kind: PodDisruptionBudget
-# metadata:
-#   name: {{ template "vault.fullname" . }}-{{.Values.Consul.ComponentName}}
-#   labels:
-    # heritage: {{ .Release.Service | quote }}
-    # release: {{ .Release.Name | quote }}
-    # chart: {{ template "vault.chart" . }}
-    # component: "{{ .Release.Name }}-{{.Values.Consul.ComponentName}}"
-# spec:
-#   maxUnavailable: 2
-#   selector:
-#     matchLabels:
-    # heritage: {{ .Release.Service | quote }}
-    # release: {{ .Release.Name | quote }}
-    # chart: {{ template "vault.chart" . }}
-    # component: "{{ .Release.Name }}-{{.Values.Consul.ComponentName}}"
+# PodDisruptionBudget to prevent degrading the Consul cluster through
+# voluntary cluster changes.
+{{- if (and (ne (.Values.Consul.maxUnavailable | toString) "-") .Values.Consul.maxUnavailable) }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "vault.fullname" . }}-{{.Values.Consul.ComponentName}}
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: {{ template "vault.chart" . }}
+    component: "{{ .Release.Name }}-{{.Values.Consul.ComponentName}}"
+spec:
+  maxUnavailable: {{ template "consul.pdb.maxUnavailable" . }}
+  selector:
+    matchLabels:
+      heritage: {{ .Release.Service | quote }}
+      release: {{ .Release.Name | quote }}
+      chart: {{ template "vault.chart" . }}
+      component: "{{ .Release.Name }}-{{.Values.Consul.ComponentName}}"
+{{- end }}
 
-
-# {{- if .Values.Consul.MaxUnavailable }}
-# apiVersion: policy/v1beta1
-# kind: PodDisruptionBudget
-# metadata:
-#   name: "{{ template "vault.fullname" . }}-{{.Values.Consul.ComponentName}}"
-#   labels:
-    # heritage: {{ .Release.Service | quote }}
-    # release: {{ .Release.Name | quote }}
-    # chart: {{ template "vault.chart" . }}
-    # component: "{{ .Release.Name }}-{{.Values.Consul.ComponentName}}"
-# spec:
-#   maxUnavailable: {{ .Values.Consul.MaxUnavailable }}
-#   selector:
-#     matchLabels:
-#       component: "{{ .Release.Name }}-{{ .Values.Consul.ComponentName }}"
-# {{- end }}

--- a/helm_charts/vault/templates/consul.statefulset.yaml
+++ b/helm_charts/vault/templates/consul.statefulset.yaml
@@ -11,7 +11,7 @@ spec:
   serviceName: "{{ template "vault.fullname" . }}-{{.Values.Consul.ComponentName}}"
   podManagementPolicy: Parallel
   updateStrategy:
-    {{- if (gt (int .Values.Consul.updatePartition) 0) }}
+  {{- if (gt (int .Values.Consul.updatePartition) 0) }}
     type: RollingUpdate
     rollingUpdate:
       partition: {{ .Values.Consul.updatePartition }}

--- a/helm_charts/vault/templates/consul.statefulset.yaml
+++ b/helm_charts/vault/templates/consul.statefulset.yaml
@@ -9,8 +9,15 @@ metadata:
     component: "{{ .Release.Name }}-{{ .Values.Consul.ComponentName }}"
 spec:
   serviceName: "{{ template "vault.fullname" . }}-{{.Values.Consul.ComponentName}}"
+  podManagementPolicy: Parallel
   updateStrategy:
+    {{- if (gt (int .Values.Consul.updatePartition) 0) }}
+    type: RollingUpdate
+    rollingUpdate:
+      partition: {{ .Values.Consul.updatePartition }}
+  {{- else -}}
     type: "OnDelete"
+  {{- end }}
   replicas: {{ .Values.Consul.Replicas }}
   selector:
     matchLabels:
@@ -25,6 +32,14 @@ spec:
         chart: {{ template "vault.chart" . }}
         component: "{{ .Release.Name }}-{{ .Values.Consul.ComponentName }}"
     spec:
+      podAntiAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                release: {{ .Release.Name | quote }}
+                component: "{{ .Release.Name }}-{{ .Values.Consul.ComponentName }}"
+            topologyKey: kubernetes.io/hostname
+      terminationGracePeriodSeconds: 10
       securityContext:
         fsGroup: 1000
       containers:

--- a/helm_charts/vault/templates/vault.deployment.yaml
+++ b/helm_charts/vault/templates/vault.deployment.yaml
@@ -73,9 +73,9 @@ spec:
           httpGet:
             scheme: HTTPS
             path: /v1/sys/health?
-              {{- if .Values.vault.readiness.readyIfSealed -}}sealedcode=204&{{- end }}
-              {{- if .Values.vault.readiness.readyIfStandby -}}standbycode=204&{{- end }}
-              {{- if .Values.vault.readiness.readyIfUninitialized -}}uninitcode=204&{{- end }}
+              {{- if .Values.Vault.Readiness.readyIfSealed -}}sealedcode=204&{{- end }}
+              {{- if .Values.Vault.Readiness.readyIfStandby -}}standbycode=204&{{- end }}
+              {{- if .Values.Vault.Readiness.readyIfUninitialized -}}uninitcode=204&{{- end }}
             port: {{.Values.Vault.HttpPort}}
           initialDelaySeconds: 5
           periodSeconds: 5

--- a/helm_charts/vault/templates/vault.deployment.yaml
+++ b/helm_charts/vault/templates/vault.deployment.yaml
@@ -64,6 +64,11 @@ spec:
                   chmod -R +x /post-start
                   /post-start/unseal-vault.sh {{ template "tls_skip_verify" . }}
         {{- end }}
+        livenessProbe:
+          httpGet:
+            scheme: HTTPS
+            path: /v1/sys/health
+            port: {{.Values.Vault.HttpPort}}
         readinessProbe:
           # Ready depends on preference
           httpGet:

--- a/helm_charts/vault/templates/vault.deployment.yaml
+++ b/helm_charts/vault/templates/vault.deployment.yaml
@@ -64,9 +64,14 @@ spec:
                   chmod -R +x /post-start
                   /post-start/unseal-vault.sh {{ template "tls_skip_verify" . }}
         {{- end }}
+        livenessProbe:
+          # Alive - if it is listening for clustering traffic
+          tcpSocket:
+            port: {{.Values.Vault.HttpPort}}
         readinessProbe:
           # Ready depends on preference
           httpGet:
+            scheme: HTTPS
             path: /v1/sys/health?
               {{- if .Values.vault.readiness.readyIfSealed -}}sealedcode=204&{{- end }}
               {{- if .Values.vault.readiness.readyIfStandby -}}standbycode=204&{{- end }}

--- a/helm_charts/vault/templates/vault.deployment.yaml
+++ b/helm_charts/vault/templates/vault.deployment.yaml
@@ -42,6 +42,8 @@ spec:
             cp /vault/config-ro/config.json /vault/config/config.json
             docker-entrypoint.sh server
         env:
+        - name: "VAULT_CACERT"
+          value: "/vault/tls/ca.crt"
         - name: "VAULT_LOG_LEVEL"
           value: "{{.Values.Vault.LogLevel}}"
         - name: "VAULT_TLS_SERVER_NAME"

--- a/helm_charts/vault/templates/vault.deployment.yaml
+++ b/helm_charts/vault/templates/vault.deployment.yaml
@@ -64,18 +64,14 @@ spec:
                   chmod -R +x /post-start
                   /post-start/unseal-vault.sh {{ template "tls_skip_verify" . }}
         {{- end }}
-        livenessProbe:
-          # Alive - if it is listening for clustering traffic
-          tcpSocket:
-            port: {{.Values.Vault.HttpPort}}
         readinessProbe:
           # Ready depends on preference
           httpGet:
             scheme: HTTPS
             path: /v1/sys/health?
-              {{- if .Values.Vault.Readiness.readyIfSealed -}}sealedcode=204&{{- end }}
-              {{- if .Values.Vault.Readiness.readyIfStandby -}}standbycode=204&{{- end }}
-              {{- if .Values.Vault.Readiness.readyIfUninitialized -}}uninitcode=204&{{- end }}
+              {{- if .Values.Vault.Readiness.readyIfSealed -}}sealedok&{{- end }}
+              {{- if .Values.Vault.Readiness.readyIfStandby -}}standbyok&{{- end }}
+              {{- if .Values.Vault.Readiness.readyIfUninitialized -}}uninitok&{{- end }}
             port: {{.Values.Vault.HttpPort}}
           initialDelaySeconds: 5
           periodSeconds: 5

--- a/helm_charts/vault/templates/vault.deployment.yaml
+++ b/helm_charts/vault/templates/vault.deployment.yaml
@@ -107,6 +107,7 @@ spec:
             cpu: {{ .Values.Vault.Cpu }}
             memory: {{ .Values.Vault.Memory }}
         securityContext:
+          readOnlyRootFilesystem: true
           capabilities:
             add:
               - IPC_LOCK

--- a/helm_charts/vault/templates/vault.deployment.yaml
+++ b/helm_charts/vault/templates/vault.deployment.yaml
@@ -9,6 +9,10 @@ metadata:
     component: "{{ .Release.Name }}-{{ .Values.Vault.ComponentName }}"
 spec:
   replicas: {{ .Values.Vault.Replicas }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
   selector:
     matchLabels:
       release: {{ .Release.Name | quote }}
@@ -61,9 +65,12 @@ spec:
                   /post-start/unseal-vault.sh {{ template "tls_skip_verify" . }}
         {{- end }}
         readinessProbe:
+          # Ready depends on preference
           httpGet:
-            scheme: HTTPS
-            path: /v1/sys/health?standbyok
+            path: /v1/sys/health?
+              {{- if .Values.vault.readiness.readyIfSealed -}}sealedcode=204&{{- end }}
+              {{- if .Values.vault.readiness.readyIfStandby -}}standbycode=204&{{- end }}
+              {{- if .Values.vault.readiness.readyIfUninitialized -}}uninitcode=204&{{- end }}
             port: {{.Values.Vault.HttpPort}}
           initialDelaySeconds: 5
           periodSeconds: 5
@@ -106,6 +113,8 @@ spec:
       - name: "{{ template "vault.fullname" . }}-{{.Values.Vault.ConsulClient.ComponentName}}"
         image: "{{.Values.Consul.Image}}:{{.Values.Consul.ImageTag}}"
         imagePullPolicy: "{{.Values.Consul.ImagePullPolicy}}"
+        securityContext:
+          readOnlyRootFilesystem: true
         ports:
         - name: http
           containerPort: {{.Values.Consul.HttpPort}}
@@ -159,6 +168,15 @@ spec:
               -config-dir=/consul/config \
               -config-dir=/consul/secrets \
               -retry-join={{ template "vault.fullname" . }}-{{.Values.Consul.ComponentName}}
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            topologyKey: kubernetes.io/hostname
+            labelSelector:
+              matchLabels:
+                release: {{ .Release.Name | quote }}
+                component: "{{ .Release.Name }}-{{ .Values.Vault.ComponentName }}"
       volumes:
       - name: config
         configMap:

--- a/helm_charts/vault/templates/vault.deployment.yaml
+++ b/helm_charts/vault/templates/vault.deployment.yaml
@@ -65,9 +65,8 @@ spec:
                   /post-start/unseal-vault.sh {{ template "tls_skip_verify" . }}
         {{- end }}
         livenessProbe:
-          httpGet:
-            scheme: HTTPS
-            path: /v1/sys/health
+          # Alive - if it is listening for clustering traffic
+          tcpSocket:
             port: {{.Values.Vault.HttpPort}}
         readinessProbe:
           # Ready depends on preference

--- a/helm_charts/vault/templates/vault.deployment.yaml
+++ b/helm_charts/vault/templates/vault.deployment.yaml
@@ -114,7 +114,6 @@ spec:
       - name: "{{ template "vault.fullname" . }}-{{.Values.Vault.ConsulClient.ComponentName}}"
         image: "{{.Values.Consul.Image}}:{{.Values.Consul.ImageTag}}"
         imagePullPolicy: "{{.Values.Consul.ImagePullPolicy}}"
-        securityContext:
         ports:
         - name: http
           containerPort: {{.Values.Consul.HttpPort}}

--- a/helm_charts/vault/templates/vault.deployment.yaml
+++ b/helm_charts/vault/templates/vault.deployment.yaml
@@ -64,6 +64,13 @@ spec:
                   chmod -R +x /post-start
                   /post-start/unseal-vault.sh {{ template "tls_skip_verify" . }}
         {{- end }}
+        livenessProbe:
+          exec:
+            command:
+            - pidof
+            - vault
+          initialDelaySeconds: 5
+          timeoutSeconds: 2
         readinessProbe:
           # Ready depends on preference
           httpGet:
@@ -167,6 +174,13 @@ spec:
               -config-dir=/consul/config \
               -config-dir=/consul/secrets \
               -retry-join={{ template "vault.fullname" . }}-{{.Values.Consul.ComponentName}}
+        livenessProbe:
+          exec:
+            command:
+            - pidof
+            - consul
+          initialDelaySeconds: 5
+          timeoutSeconds: 2
       podAntiAffinity:
         preferredDuringSchedulingIgnoredDuringExecution:
         - weight: 100

--- a/helm_charts/vault/templates/vault.deployment.yaml
+++ b/helm_charts/vault/templates/vault.deployment.yaml
@@ -68,10 +68,7 @@ spec:
           # Ready depends on preference
           httpGet:
             scheme: HTTPS
-            path: /v1/sys/health?
-              {{- if .Values.Vault.Readiness.readyIfStandby -}}standbycode=429&{{- end }}
-              {{- if .Values.Vault.Readiness.readyIfSealed -}}sealedcode=503&{{- end }}
-              {{- if .Values.Vault.Readiness.readyIfUninitialized -}}uninitcode=501&{{- end }}
+            path: /v1/sys/health?standbyok
             port: {{.Values.Vault.HttpPort}}
           initialDelaySeconds: 5
           periodSeconds: 5

--- a/helm_charts/vault/templates/vault.deployment.yaml
+++ b/helm_charts/vault/templates/vault.deployment.yaml
@@ -69,9 +69,9 @@ spec:
           httpGet:
             scheme: HTTPS
             path: /v1/sys/health?
-              {{- if .Values.Vault.Readiness.readyIfSealed -}}sealedok&{{- end }}
-              {{- if .Values.Vault.Readiness.readyIfStandby -}}standbyok&{{- end }}
-              {{- if .Values.Vault.Readiness.readyIfUninitialized -}}uninitok&{{- end }}
+              {{- if .Values.Vault.Readiness.readyIfStandby -}}standbycode=429&{{- end }}
+              {{- if .Values.Vault.Readiness.readyIfSealed -}}sealedcode=503&{{- end }}
+              {{- if .Values.Vault.Readiness.readyIfUninitialized -}}uninitcode=501&{{- end }}
             port: {{.Values.Vault.HttpPort}}
           initialDelaySeconds: 5
           periodSeconds: 5

--- a/helm_charts/vault/templates/vault.deployment.yaml
+++ b/helm_charts/vault/templates/vault.deployment.yaml
@@ -64,10 +64,6 @@ spec:
                   chmod -R +x /post-start
                   /post-start/unseal-vault.sh {{ template "tls_skip_verify" . }}
         {{- end }}
-        livenessProbe:
-          # Alive - if it is listening for clustering traffic
-          tcpSocket:
-            port: {{.Values.Vault.HttpPort}}
         readinessProbe:
           # Ready depends on preference
           httpGet:

--- a/helm_charts/vault/templates/vault.deployment.yaml
+++ b/helm_charts/vault/templates/vault.deployment.yaml
@@ -112,7 +112,6 @@ spec:
             cpu: {{ .Values.Vault.Cpu }}
             memory: {{ .Values.Vault.Memory }}
         securityContext:
-          readOnlyRootFilesystem: true
           capabilities:
             add:
               - IPC_LOCK
@@ -120,7 +119,6 @@ spec:
         image: "{{.Values.Consul.Image}}:{{.Values.Consul.ImageTag}}"
         imagePullPolicy: "{{.Values.Consul.ImagePullPolicy}}"
         securityContext:
-          readOnlyRootFilesystem: true
         ports:
         - name: http
           containerPort: {{.Values.Consul.HttpPort}}

--- a/helm_charts/vault/templates/vault.deployment.yaml
+++ b/helm_charts/vault/templates/vault.deployment.yaml
@@ -68,7 +68,10 @@ spec:
           # Ready depends on preference
           httpGet:
             scheme: HTTPS
-            path: /v1/sys/health?standbyok
+            path: /v1/sys/health?
+              {{- if .Values.Vault.Readiness.readyIfStandby -}}standbycode=429&{{- end }}
+              {{- if .Values.Vault.Readiness.readyIfSealed -}}sealedcode=503&{{- end }}
+              {{- if .Values.Vault.Readiness.readyIfUninitialized -}}uninitcode=501&{{- end }}
             port: {{.Values.Vault.HttpPort}}
           initialDelaySeconds: 5
           periodSeconds: 5

--- a/helm_charts/vault/templates/vault.deployment.yaml
+++ b/helm_charts/vault/templates/vault.deployment.yaml
@@ -68,7 +68,10 @@ spec:
           # Ready depends on preference
           httpGet:
             scheme: HTTPS
-            path: /v1/sys/health?standbyok
+            path: /v1/sys/health?
+              {{- if .Values.Vault.Readiness.readyIfStandby -}}standbycode=204&{{- end }}
+              {{- if .Values.Vault.Readiness.readyIfSealed -}}sealedcode=204&{{- end }}
+              {{- if .Values.Vault.Readiness.readyIfUninitialized -}}uninitcode=204&{{- end }}
             port: {{.Values.Vault.HttpPort}}
           initialDelaySeconds: 5
           periodSeconds: 5

--- a/helm_charts/vault/templates/vault.pdb.yaml
+++ b/helm_charts/vault/templates/vault.pdb.yaml
@@ -1,0 +1,22 @@
+# PodDisruptionBudget to prevent degrading the Vault cluster through
+# voluntary cluster changes.
+{{- if (and (ne (.Values.Vault.maxUnavailable | toString) "-") .Values.Vault.maxUnavailable) }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "vault.fullname" . }}-{{.Values.Vault.ComponentName}}
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: {{ template "vault.chart" . }}
+    component: "{{ .Release.Name }}-{{.Values.Vault.ComponentName}}"
+spec:
+  maxUnavailable: {{ template "vault.pdb.maxUnavailable" . }}
+  selector:
+    matchLabels:
+      heritage: {{ .Release.Service | quote }}
+      release: {{ .Release.Name | quote }}
+      chart: {{ template "vault.chart" . }}
+      component: "{{ .Release.Name }}-{{.Values.Vault.ComponentName}}"
+{{- end }}
+

--- a/helm_charts/vault/templates/vault.preInstall.customCA.job.yaml
+++ b/helm_charts/vault/templates/vault.preInstall.customCA.job.yaml
@@ -37,7 +37,7 @@ spec:
           - name: SSL_SUBJECT
             value: "{{.Values.Vault.Tls.ServerName}}"
           - name: SSL_DNS
-            value: "{{.Values.Vault.Tls.AlternateServerNames}}"
+            value: "{{.Values.Vault.Tls.AlternateServerNames}},{{- .Release.Name -}}.{{- .Release.Namespace -}}.svc.cluster.local"
           - name: SILENT
             value: "true"
           - name: K8S_SECRET_NAME

--- a/helm_charts/vault/templates/vault.preInstall.customCA.job.yaml
+++ b/helm_charts/vault/templates/vault.preInstall.customCA.job.yaml
@@ -42,7 +42,7 @@ spec:
             value: "true"
           - name: K8S_SECRET_NAME
             value: "{{ template "vault.fullname" . }}.tls"
-          - name: K8S_SECRET_COMBINE_CA
+          - name: K8S_SECRET_SEPARATE_CA
             value: "true"
           - name: K8S_SECRET_LABELS
             value: "heritage={{ .Release.Service }} release={{ .Release.Name }} chart={{ template "vault.chart" . }} component={{ .Release.Name }}-{{.Values.Vault.PreInstall.ComponentName}}"

--- a/helm_charts/vault/values.yaml
+++ b/helm_charts/vault/values.yaml
@@ -11,7 +11,7 @@ Consul:
   ImagePullPolicy: "IfNotPresent"
   Memory: "256Mi"
   Replicas: 5
-  maxUnavailable: ""
+  maxUnavailable: 2
   HttpPort: 8500
   SerflanPort: 8301
   SerflanUdpPort: 8301
@@ -62,7 +62,7 @@ Vault:
   ImagePullPolicy: "IfNotPresent"
   LogLevel: "info"
   Replicas: 3
-  maxUnavailable: ""
+  maxUnavailable: 1
   Cpu: "512m"
   Memory: "200Mi"
   # HostAliases:

--- a/helm_charts/vault/values.yaml
+++ b/helm_charts/vault/values.yaml
@@ -73,7 +73,7 @@ Vault:
   DisableConsulRegistration: "false"
   DefaultLeaseTtl: "768h"
   MaxLeaseTtl: "768h"
-  readiness:
+  Readiness:
     readyIfSealed: false
     readyIfStandby: true
     readyIfUninitialized: true

--- a/helm_charts/vault/values.yaml
+++ b/helm_charts/vault/values.yaml
@@ -74,8 +74,8 @@ Vault:
   DefaultLeaseTtl: "768h"
   MaxLeaseTtl: "768h"
   Readiness:
-    readyIfSealed: false
     readyIfStandby: true
+    readyIfSealed: false
     readyIfUninitialized: true
   ConsulClient:
     ComponentName: "consul-client"

--- a/helm_charts/vault/values.yaml
+++ b/helm_charts/vault/values.yaml
@@ -7,10 +7,11 @@ Consul:
   Cpu: "100m"
   Datacenter: "dc1"
   Image: "consul"
-  ImageTag: "0.9.2"
+  ImageTag: "1.4.2"
   ImagePullPolicy: "IfNotPresent"
   Memory: "256Mi"
   Replicas: 5
+  maxUnavailable: ""
   HttpPort: 8500
   SerflanPort: 8301
   SerflanUdpPort: 8301
@@ -57,10 +58,11 @@ Vault:
     Enabled: true # If enabled, will use service type ClusterIP
   NodePort: 30825 # Ignored if Ingress.Enabled = true
   Image: "vault"
-  ImageTag: "0.9.5"
+  ImageTag: "1.0.3"
   ImagePullPolicy: "IfNotPresent"
   LogLevel: "info"
   Replicas: 3
+  maxUnavailable: ""
   Cpu: "512m"
   Memory: "200Mi"
   # HostAliases:

--- a/helm_charts/vault/values.yaml
+++ b/helm_charts/vault/values.yaml
@@ -22,7 +22,7 @@ Consul:
   ConsulDnsPort: 8600
   PreInstall:
     ComponentName: "consul-preinstall"
-    JobDeadline: 30
+    JobDeadline: 60
     Tls:
       CountryName: "US"
       LocalityName: "placeholder"
@@ -81,7 +81,7 @@ Vault:
     ComponentName: "consul-client"
   PreInstall:
     ComponentName: "vault-preinstall"
-    JobDeadline: 200
+    JobDeadline: 60
   Tls:
     ServerName: "vault.consul"
     AlternateServerNames: "vault-alt.consul" # Comma separated

--- a/helm_charts/vault/values.yaml
+++ b/helm_charts/vault/values.yaml
@@ -12,6 +12,7 @@ Consul:
   Memory: "256Mi"
   Replicas: 5
   maxUnavailable: 2
+  updatePartition: 0  # Use to control a careful rolling update.
   HttpPort: 8500
   SerflanPort: 8301
   SerflanUdpPort: 8301
@@ -72,6 +73,10 @@ Vault:
   DisableConsulRegistration: "false"
   DefaultLeaseTtl: "768h"
   MaxLeaseTtl: "768h"
+  readiness:
+    readyIfSealed: false
+    readyIfStandby: true
+    readyIfUninitialized: true
   ConsulClient:
     ComponentName: "consul-client"
   PreInstall:

--- a/helm_charts/vault/values.yaml
+++ b/helm_charts/vault/values.yaml
@@ -4,12 +4,12 @@
 # Consul storage backend configuration
 Consul:
   ComponentName: "consul"
-  Cpu: "100m"
+  Cpu: "150m"
   Datacenter: "dc1"
   Image: "consul"
-  ImageTag: "1.4.2"
+  ImageTag: "1.4.4"
   ImagePullPolicy: "IfNotPresent"
-  Memory: "256Mi"
+  Memory: "320Mi"
   Replicas: 5
   maxUnavailable: 2
   updatePartition: 0  # Use to control a careful rolling update.
@@ -59,13 +59,13 @@ Vault:
     Enabled: true # If enabled, will use service type ClusterIP
   NodePort: 30825 # Ignored if Ingress.Enabled = true
   Image: "vault"
-  ImageTag: "1.0.3"
+  ImageTag: "1.1.0"
   ImagePullPolicy: "IfNotPresent"
   LogLevel: "info"
   Replicas: 3
   maxUnavailable: 1
   Cpu: "512m"
-  Memory: "200Mi"
+  Memory: "384Mi"
   # HostAliases:
   # - ip: "127.0.0.1"
   #   hostnames:
@@ -81,7 +81,7 @@ Vault:
     ComponentName: "consul-client"
   PreInstall:
     ComponentName: "vault-preinstall"
-    JobDeadline: 100
+    JobDeadline: 200
   Tls:
     ServerName: "vault.consul"
     AlternateServerNames: "vault-alt.consul" # Comma separated
@@ -92,7 +92,7 @@ Vault:
       Environment: "stage" # production/stage
       AcmeAccountKey: "s3://<bucket-name>/stage.pem"
   Ui:
-    Enabled: false
+    Enabled: true
 Misc:
   kubectl:
     Image: "bartlettc/docker-kubectl"

--- a/helm_charts/vault/values.yaml
+++ b/helm_charts/vault/values.yaml
@@ -73,10 +73,6 @@ Vault:
   DisableConsulRegistration: "false"
   DefaultLeaseTtl: "768h"
   MaxLeaseTtl: "768h"
-  Readiness:
-    readyIfStandby: true
-    readyIfSealed: false
-    readyIfUninitialized: true
   ConsulClient:
     ComponentName: "consul-client"
   PreInstall:

--- a/helm_charts/vault/values.yaml
+++ b/helm_charts/vault/values.yaml
@@ -73,6 +73,10 @@ Vault:
   DisableConsulRegistration: "false"
   DefaultLeaseTtl: "768h"
   MaxLeaseTtl: "768h"
+  Readiness:
+    readyIfStandby: true
+    readyIfSealed: false
+    readyIfUninitialized: true
   ConsulClient:
     ComponentName: "consul-client"
   PreInstall:


### PR DESCRIPTION
Hey folks!

I've completed a couple of changes:
*(1)* Introducing PodDisruptionBudget and podAntiAffinity.
*(2)* Improving podManagementPolicy, Vault's readinessProbe and adding livenessProbe's.
*(3)* Skipping TLS verification is no longer required from within the Vault pods.
*(4)* Easier DNS resolution through K8S Ingress - using Vault's K8S service.
*(5)* Fixes for the `NOTES.txt`.
*(6)* Bumping ImageTag versions.
*(7)* Bumping the chart version to `0.2.0` and adding Contributors Acknowledgement section.