### PR TITLE
Ability to Use AWS S3 as "storage" and Consul only as "ha_storage". Add ability to auto-unseal using AWS KMS key. Add Ability to Use Pre-Created Self-Signed Certs. Address Helm v2.14 New Validation Rules. Use "soft" AntiAffinities. Fix Ingress over TLS. Bump Vault and Consul Versions. Fix Consul Backup. Fix GitHub's Chart URL in README.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
-# v0.2.1
+# v0.2.5
+* Add ability to use AWS S3 as Vault's Data Storage ("storage") and Consul only as Vault's High Availability Storage ("ha_storage")
 * Address Helm v2.14 New Validation Rules (https://github.com/helm/helm/pull/5576)
 * Use "Soft" AntiAffinities to allow deployment to single node services such as microK8s or Minikube
 * Bumped Vault to 1.1.2 and Consul to 1.5.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # v0.2.5
 * Add ability to use AWS S3 as Vault's Data Storage ("storage") and Consul only as Vault's High Availability Storage ("ha_storage")
 * Add ability to auto-unseal using AWS KMS key
+* Add ability to use manually pre-created self-signed certs.
 * Address Helm v2.14 New Validation Rules (https://github.com/helm/helm/pull/5576)
 * Use "Soft" AntiAffinities to allow deployment to single node services such as microK8s or Minikube
+* Fix Ingress over TLS.
+* Fix GitHub's Chart URL in `README.md`.
 * Bumped Vault to v1.2.2 and Consul to v1.6.0
 
 # v0.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 * Add ability to use AWS S3 as Vault's Data Storage ("storage") and Consul only as Vault's High Availability Storage ("ha_storage")
 * Address Helm v2.14 New Validation Rules (https://github.com/helm/helm/pull/5576)
 * Use "Soft" AntiAffinities to allow deployment to single node services such as microK8s or Minikube
-* Bumped Vault to 1.1.2 and Consul to 1.5.1
+* Bumped Vault to v1.2.1 and Consul to v1.5.3
 
 # v0.2.0
 * Added Pod Disruptions Budgets (PDBs) to Consul and Vault

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # v0.2.5
 * Add ability to use AWS S3 as Vault's Data Storage ("storage") and Consul only as Vault's High Availability Storage ("ha_storage")
+* Add ability to auto-unseal using AWS KMS key
 * Address Helm v2.14 New Validation Rules (https://github.com/helm/helm/pull/5576)
 * Use "Soft" AntiAffinities to allow deployment to single node services such as microK8s or Minikube
-* Bumped Vault to v1.2.1 and Consul to v1.5.3
+* Bumped Vault to v1.2.2 and Consul to v1.6.0
 
 # v0.2.0
 * Added Pod Disruptions Budgets (PDBs) to Consul and Vault

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v0.2.1
+* Address Helm v2.14 New Validation Rules (https://github.com/helm/helm/pull/5576)
+* Use "Soft" AntiAffinities to allow deployment to single node services such as microK8s or Minikube
+* Bumped Vault to 1.1.1 and Consul to 1.5.1
+
 # v0.2.0
 * Added Pod Disruptions Budgets (PDBs) to Consul and Vault
 * Added optional rolling update partitioning for Consul

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # v0.2.1
 * Address Helm v2.14 New Validation Rules (https://github.com/helm/helm/pull/5576)
 * Use "Soft" AntiAffinities to allow deployment to single node services such as microK8s or Minikube
-* Bumped Vault to 1.1.1 and Consul to 1.5.1
+* Bumped Vault to 1.1.2 and Consul to 1.5.1
 
 # v0.2.0
 * Added Pod Disruptions Budgets (PDBs) to Consul and Vault

--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ It isn't hard to [get started](https://www.vaultproject.io/intro/getting-started
 | `Consul.Restore.AwsAccessKeyId` | AWS key with access to the restore s3 location |  |
 | `Consul.Restore.AwsSecretAccessKey` | AWS secret key with access to the restore s3 location | |
 | `Vault.ComponentName` | Used for resource names and labeling | `vault` |
+| `Vault.DataStorage` | Vault's "storage" backend | `consul` |
+| `Vault.awsAccessKey` | Vault's AWS S3 "storage" backend Access Key | |
+| `Vault.awsSecretKey` | Vault's AWS S3 "storage" backend Secret Key | |
+| `Vault.awsBucket` | Vault's AWS S3 "storage" backend Bucket | |
+| `Vault.awsBucketRegion` | Vault's AWS S3 "storage" backend Bucket Region | |
+| `Vault.awsKmsKeyId` | Vault's AWS S3 "storage" backend Bucket KMS Customer-Managed Key ID | |
 | `Vault.AutoUnseal` | Vault auto-unsealing (deprecated) | `false` |
 | `Vault.HttpPort` | Vault http listening port | `8200` |
 | `Vault.HaForwardingPort` | Vault high-availability port-forwarding port | `8201` |

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ It isn't hard to [get started](https://www.vaultproject.io/intro/getting-started
 | `Consul.Cpu` | Consul container requested cpu | `100m` |
 | `Consul.Datacenter` | Consul datacenter name | `dc1` |
 | `Consul.Image` | Consul container image name | `consul` |
-| `Consul.ImageTag` | Consul container image tag | `1.5.3` |
+| `Consul.ImageTag` | Consul container image tag | `1.6.0` |
 | `Consul.ImagePullPolicy` | Consul container pull policy | `IfNotPresent` |
 | `Consul.Memory` | Consul container requested memory | `256Mi` |
 | `Consul.Replicas` | Consul container replicas | `5` |
@@ -78,19 +78,21 @@ It isn't hard to [get started](https://www.vaultproject.io/intro/getting-started
 | `Consul.Restore.AwsAccessKeyId` | AWS key with access to the restore s3 location |  |
 | `Consul.Restore.AwsSecretAccessKey` | AWS secret key with access to the restore s3 location | |
 | `Vault.ComponentName` | Used for resource names and labeling | `vault` |
+| `Vault.awsAccessKey` | Vault's AWS Access Key |  |
+| `Vault.awsSecretKey` | Vault's AWS Secret Key |  |
+| `Vault.awsRegion` | Vault's AWS Region |  |
 | `Vault.DataStorage` | Vault's "storage" backend | `consul` |
-| `Vault.awsAccessKey` | Vault's AWS S3 "storage" backend Access Key |  |
-| `Vault.awsSecretKey` | Vault's AWS S3 "storage" backend Secret Key |  |
 | `Vault.awsBucketName` | Vault's AWS S3 "storage" backend Bucket name |  |
-| `Vault.awsBucketRegion` | Vault's AWS S3 "storage" backend Bucket Region |  |
-| `Vault.awsKmsKeyId` | Vault's AWS S3 "storage" backend Bucket KMS Customer-Managed Key ID |  |
-| `Vault.AutoUnseal` | Vault auto-unsealing (deprecated) | `false` |
+| `Vault.awsBucketKmsKeyId` | Vault's AWS S3 "storage" backend Bucket KMS Customer-Managed Key ID |  |
+| `Vault.AutoUnseal` | (deprecated) Vault auto-unsealing using an auto-populated K8s secret | `false` |
+| `Vault.unsealAwsKmsKey` | Vault auto-unsealing using an AWS KMS key | `-` |
+| `Vault.unsealAwsKmsEndpoint` | The AWS KMS VPCe (internal end-point) for Vault's auto-unsealing | `-` |
 | `Vault.HttpPort` | Vault http listening port | `8200` |
 | `Vault.HaForwardingPort` | Vault high-availability port-forwarding port | `8201` |
 | `Vault.Ingress.Enabled` | Enable ingress. If enabled, will use service type ClusterIP | `true` |
 | `Vault.NodePort` | Vault service NodePort to open. Ignored if Ingress.Enabled = true  | `30825` |
 | `Vault.Image` | Vault container image name | `vault` |
-| `Vault.ImageTag` | Vault container image tag | `1.2.1` |
+| `Vault.ImageTag` | Vault container image tag | `1.2.2` |
 | `Vault.ImagePullPolicy` | Vault container pull policy | `IfNotPresent`
 | `Vault.LogLevel` | Set vault log level (trace, debug, info, etc.) | `info` |
 | `Vault.Replicas` | Vault container replicas | `3` |

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ It isn't hard to [get started](https://www.vaultproject.io/intro/getting-started
 | `Consul.Cpu` | Consul container requested cpu | `100m` |
 | `Consul.Datacenter` | Consul datacenter name | `dc1` |
 | `Consul.Image` | Consul container image name | `consul` |
-| `Consul.ImageTag` | Consul container image tag | `0.9.2` |
+| `Consul.ImageTag` | Consul container image tag | `1.5.3` |
 | `Consul.ImagePullPolicy` | Consul container pull policy | `IfNotPresent` |
 | `Consul.Memory` | Consul container requested memory | `256Mi` |
 | `Consul.Replicas` | Consul container replicas | `5` |
@@ -68,7 +68,9 @@ It isn't hard to [get started](https://www.vaultproject.io/intro/getting-started
 | `Consul.Backup.ImageTag` | Consul backup container image tag | `latest` |
 | `Consul.Backup.Cpu` | Consul backup requested cpu | `512m` |
 | `Consul.Backup.Memory` | Consul backup container requested memory | `200Mi` |
-| `Consul.Backup.S3URL` | Consul backups S3 bucket path, e.g `s3://my-bucket` (helm `.Release.Name` will get added to the end) |  |
+| `Consul.Backup.S3URL` | Consul backups S3 bucket path, e.g `s3://my-bucket` |  |
+| `Consul.Backup.AwsAccessKeyId` | AWS Access Key with access to the backup AWS S3 location |  |
+| `Consul.Backup.AwsSecretAccessKey` | AWS Secret Key with access to the backup AWS S3 location |  |
 | `Consul.Backup.SleepDuration` | Backup interval (in seconds) | `7200` |
 | `Consul.Restore.ComponentName` | Used for resource names and labeling | `restore` |
 | `Consul.Restore.S3URL` | Full restore S3 bucket path, e.g. `s3://my-bucket/vault-a/` |  |
@@ -77,18 +79,18 @@ It isn't hard to [get started](https://www.vaultproject.io/intro/getting-started
 | `Consul.Restore.AwsSecretAccessKey` | AWS secret key with access to the restore s3 location | |
 | `Vault.ComponentName` | Used for resource names and labeling | `vault` |
 | `Vault.DataStorage` | Vault's "storage" backend | `consul` |
-| `Vault.awsAccessKey` | Vault's AWS S3 "storage" backend Access Key | |
-| `Vault.awsSecretKey` | Vault's AWS S3 "storage" backend Secret Key | |
-| `Vault.awsBucket` | Vault's AWS S3 "storage" backend Bucket | |
-| `Vault.awsBucketRegion` | Vault's AWS S3 "storage" backend Bucket Region | |
-| `Vault.awsKmsKeyId` | Vault's AWS S3 "storage" backend Bucket KMS Customer-Managed Key ID | |
+| `Vault.awsAccessKey` | Vault's AWS S3 "storage" backend Access Key |  |
+| `Vault.awsSecretKey` | Vault's AWS S3 "storage" backend Secret Key |  |
+| `Vault.awsBucketName` | Vault's AWS S3 "storage" backend Bucket name |  |
+| `Vault.awsBucketRegion` | Vault's AWS S3 "storage" backend Bucket Region |  |
+| `Vault.awsKmsKeyId` | Vault's AWS S3 "storage" backend Bucket KMS Customer-Managed Key ID |  |
 | `Vault.AutoUnseal` | Vault auto-unsealing (deprecated) | `false` |
 | `Vault.HttpPort` | Vault http listening port | `8200` |
 | `Vault.HaForwardingPort` | Vault high-availability port-forwarding port | `8201` |
 | `Vault.Ingress.Enabled` | Enable ingress. If enabled, will use service type ClusterIP | `true` |
 | `Vault.NodePort` | Vault service NodePort to open. Ignored if Ingress.Enabled = true  | `30825` |
 | `Vault.Image` | Vault container image name | `vault` |
-| `Vault.ImageTag` | Vault container image tag | `0.9.0` |
+| `Vault.ImageTag` | Vault container image tag | `1.2.1` |
 | `Vault.ImagePullPolicy` | Vault container pull policy | `IfNotPresent`
 | `Vault.LogLevel` | Set vault log level (trace, debug, info, etc.) | `info` |
 | `Vault.Replicas` | Vault container replicas | `3` |
@@ -129,7 +131,7 @@ Additional dependencies
 
 Checkout the repo:
 ```bash
-git clone https://github.com/ReadyTalk/vault-helm-chart.git
+git clone https://github.com/PremiereGlobal/vault-helm-chart.git
 cd vault-helm-chart
 ```
 

--- a/helm_charts/vault/Chart.yaml
+++ b/helm_charts/vault/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Hashicorp Vault chart for Kubernetes
 name: vault
-version: 0.2.1
+version: 0.2.5
 keywords: [hashicorp, vault, secret, consul]
 icon: https://raw.githubusercontent.com/docker-library/docs/726714ced14b1e14b6dd99fc82f20f14f1d3cfb1/vault/logo.png
 sources:

--- a/helm_charts/vault/Chart.yaml
+++ b/helm_charts/vault/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Hashicorp Vault chart for Kubernetes
 name: vault
-version: 0.2.0
+version: 0.2.1
 keywords: [hashicorp, vault, secret, consul]
 icon: https://raw.githubusercontent.com/docker-library/docs/726714ced14b1e14b6dd99fc82f20f14f1d3cfb1/vault/logo.png
 sources:

--- a/helm_charts/vault/templates/consul.backup.deployment.yaml
+++ b/helm_charts/vault/templates/consul.backup.deployment.yaml
@@ -31,6 +31,10 @@ spec:
           value: -config-dir=/consul/config -config-dir=/consul/secrets
         - name: "S3_URL"
           value: {{.Values.Consul.Backup.S3URL}}/
+        - name: "AWS_ACCESS_KEY_ID"
+          value: {{.Values.Consul.Backup.AwsAccessKeyId | quote}}
+        - name: "AWS_SECRET_ACCESS_KEY"
+          value: {{.Values.Consul.Backup.AwsSecretAccessKey | quote}}
         - name: "SLEEP_DURATION"
           value: {{.Values.Consul.Backup.SleepDuration | quote}}
         resources:

--- a/helm_charts/vault/templates/consul.statefulset.yaml
+++ b/helm_charts/vault/templates/consul.statefulset.yaml
@@ -41,7 +41,7 @@ spec:
               labelSelector:
                 matchLabels:
                   release: {{ .Release.Name | quote }}
-                  component: "{{ .Release.Name }}-{{ .Values.Vault.ComponentName }}"
+                  component: "{{ .Release.Name }}-{{ .Values.Consul.ComponentName }}"
       terminationGracePeriodSeconds: 10
       securityContext:
         fsGroup: 1000

--- a/helm_charts/vault/templates/consul.statefulset.yaml
+++ b/helm_charts/vault/templates/consul.statefulset.yaml
@@ -15,7 +15,7 @@ spec:
     type: RollingUpdate
     rollingUpdate:
       partition: {{ .Values.Consul.updatePartition }}
-  {{- else -}}
+  {{- else }}
     type: "OnDelete"
   {{- end }}
   replicas: {{ .Values.Consul.Replicas }}
@@ -32,13 +32,16 @@ spec:
         chart: {{ template "vault.chart" . }}
         component: "{{ .Release.Name }}-{{ .Values.Consul.ComponentName }}"
     spec:
-      podAntiAffinity:
-        requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                release: {{ .Release.Name | quote }}
-                component: "{{ .Release.Name }}-{{ .Values.Consul.ComponentName }}"
-            topologyKey: kubernetes.io/hostname
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchLabels:
+                  release: {{ .Release.Name | quote }}
+                  component: "{{ .Release.Name }}-{{ .Values.Vault.ComponentName }}"
       terminationGracePeriodSeconds: 10
       securityContext:
         fsGroup: 1000

--- a/helm_charts/vault/templates/vault.configMap.yaml
+++ b/helm_charts/vault/templates/vault.configMap.yaml
@@ -21,11 +21,12 @@ data:
     }
     {{- if eq (.Values.Vault.DataStorage | toString) "s3" }}
     storage "s3" {
-      access_key = {{- (.Values.Vault.awsAccessKey | toString) -}}
-      secret_key = {{- (.Values.Vault.awsSecretKey | toString) -}}
-      bucket     = {{- (.Values.Vault.awsBucket | toString) -}}
+      access_key = {{ (.Values.Vault.awsAccessKey | toString | quote) }}
+      secret_key = {{ (.Values.Vault.awsSecretKey | toString | quote) }}
+      bucket     = {{ (.Values.Vault.awsBucket | toString | quote) }}
+      region     = {{ (.Values.Vault.awsBucketRegion | toString | quote) }}
       {{- if ne (.Values.Vault.awsKmsKeyId | toString) "-" }}
-      kms_key_id = {{- (.Values.Vault.awsKmsKeyId | toString) -}}
+      kms_key_id = {{ (.Values.Vault.awsKmsKeyId | toString | quote) }}
       {{- end }}
     }
     {{- end }}

--- a/helm_charts/vault/templates/vault.configMap.yaml
+++ b/helm_charts/vault/templates/vault.configMap.yaml
@@ -24,11 +24,22 @@ data:
       access_key = {{ (.Values.Vault.awsAccessKey | toString | quote) }}
       secret_key = {{ (.Values.Vault.awsSecretKey | toString | quote) }}
       bucket     = {{ (.Values.Vault.awsBucketName | toString | quote) }}
-      region     = {{ (.Values.Vault.awsBucketRegion | toString | quote) }}
-      {{- if ne (.Values.Vault.awsKmsKeyId | toString) "-" }}
-      kms_key_id = {{ (.Values.Vault.awsKmsKeyId | toString | quote) }}
+      region     = {{ (.Values.Vault.awsRegion | toString | quote) }}
+      {{- if ne (.Values.Vault.awsBucketKmsKeyId | toString) "-" }}
+      kms_key_id = {{ (.Values.Vault.awsBucketKmsKeyId | toString | quote) }}
       {{- end }}
     }
+    {{- end }}
+    {{- if ne (.Values.Vault.unsealAwsKmsKey | toString) "-" }}
+      seal "awskms" {
+      {{- if ne (.Values.Vault.unsealAwsKmsEndpoint | toString) "-" }}
+        endpoint   = {{ (.Values.Vault.unsealAwsKmsEndpoint | toString | quote) }}
+      {{- end }}
+        kms_key_id = {{ (.Values.Vault.unsealAwsKmsKey | toString | quote) }}
+        region     = {{ (.Values.Vault.awsRegion | toString | quote) }}
+        access_key = {{ (.Values.Vault.awsAccessKey | toString | quote) }}
+        secret_key = {{ (.Values.Vault.awsSecretKey | toString | quote) }}
+      }
     {{- end }}
     listener "tcp" {
       address = "0.0.0.0:{{.Values.Vault.HttpPort}}"

--- a/helm_charts/vault/templates/vault.configMap.yaml
+++ b/helm_charts/vault/templates/vault.configMap.yaml
@@ -10,11 +10,25 @@ metadata:
     component: "{{ .Release.Name }}-{{ .Values.Vault.ComponentName }}"
 data:
   config.json : |
+    {{- if eq (.Values.Vault.DataStorage | toString) "s3" }}
+    ha_storage "consul" {
+    {{- else }}
     storage "consul" {
+    {{- end }}
       address = "unix:///consul-unix-socket/consul-client.sock"
       scheme = "http"
       disable_registration = "{{default "false" .Values.Vault.DisableConsulRegistration}}"
     }
+    {{- if eq (.Values.Vault.DataStorage | toString) "s3" }}
+    storage "s3" {
+      access_key = {{- (.Values.Vault.awsAccessKey | toString) -}}
+      secret_key = {{- (.Values.Vault.awsSecretKey | toString) -}}
+      bucket     = {{- (.Values.Vault.awsBucket | toString) -}}
+      {{- if ne (.Values.Vault.awsKmsKeyId | toString) "-" }}
+      kms_key_id = {{- (.Values.Vault.awsKmsKeyId | toString) -}}
+      {{- end }}
+    }
+    {{- end }}
     listener "tcp" {
       address = "0.0.0.0:{{.Values.Vault.HttpPort}}"
       tls_key_file = "/vault/tls/tls.key"

--- a/helm_charts/vault/templates/vault.configMap.yaml
+++ b/helm_charts/vault/templates/vault.configMap.yaml
@@ -23,7 +23,7 @@ data:
     storage "s3" {
       access_key = {{ (.Values.Vault.awsAccessKey | toString | quote) }}
       secret_key = {{ (.Values.Vault.awsSecretKey | toString | quote) }}
-      bucket     = {{ (.Values.Vault.awsBucket | toString | quote) }}
+      bucket     = {{ (.Values.Vault.awsBucketName | toString | quote) }}
       region     = {{ (.Values.Vault.awsBucketRegion | toString | quote) }}
       {{- if ne (.Values.Vault.awsKmsKeyId | toString) "-" }}
       kms_key_id = {{ (.Values.Vault.awsKmsKeyId | toString | quote) }}

--- a/helm_charts/vault/templates/vault.deployment.yaml
+++ b/helm_charts/vault/templates/vault.deployment.yaml
@@ -181,15 +181,16 @@ spec:
             - consul
           initialDelaySeconds: 5
           timeoutSeconds: 2
-      podAntiAffinity:
-        preferredDuringSchedulingIgnoredDuringExecution:
-        - weight: 100
-          podAffinityTerm:
-            topologyKey: kubernetes.io/hostname
-            labelSelector:
-              matchLabels:
-                release: {{ .Release.Name | quote }}
-                component: "{{ .Release.Name }}-{{ .Values.Vault.ComponentName }}"
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchLabels:
+                  release: {{ .Release.Name | quote }}
+                  component: "{{ .Release.Name }}-{{ .Values.Vault.ComponentName }}"
       volumes:
       - name: config
         configMap:

--- a/helm_charts/vault/templates/vault.ingress.yaml
+++ b/helm_charts/vault/templates/vault.ingress.yaml
@@ -25,14 +25,4 @@ spec:
           backend:
             serviceName: {{ template "vault.fullname" . }}
             servicePort: {{.Values.Vault.HttpPort}}
-    {{- $root := . -}}
-    {{- range .Values.Vault.Tls.AlternateServerNames | split "," }}
-    - host: {{ . | quote }}
-      http:
-        paths:
-        - path: /
-          backend:
-            serviceName: "{{ template "vault.fullname" $root }}"
-            servicePort: {{$root.Values.Vault.HttpPort}}
-    {{- end }}
 {{- end }}

--- a/helm_charts/vault/templates/vault.ingress.yaml
+++ b/helm_charts/vault/templates/vault.ingress.yaml
@@ -10,7 +10,13 @@ metadata:
     component: "{{ .Release.Name }}-{{ .Values.Vault.ComponentName }}"
   annotations:
     kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/ssl-passthrough: "true"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
 spec:
+  tls:
+  - hosts:
+    - {{.Values.Vault.Tls.ServerName}}
+    secretName: "{{ template "vault.fullname" . }}.tls"
   rules:
     - host: {{.Values.Vault.Tls.ServerName}}
       http:

--- a/helm_charts/vault/templates/vault.tls.secret.yaml
+++ b/helm_charts/vault/templates/vault.tls.secret.yaml
@@ -10,6 +10,9 @@ metadata:
     component: "{{ .Release.Name }}-{{ .Values.Vault.ComponentName }}"
 type: kubernetes.io/tls
 data:
+  {{- if .Values.Vault.Tls.caString }}
+  ca.crt: {{ .Values.Vault.Tls.caString | b64enc }}
+  {{- end }}
   tls.crt: {{ .Values.Vault.Tls.CertString | b64enc }}
   tls.key: {{ .Values.Vault.Tls.KeyString | b64enc }}
 {{- end }}

--- a/helm_charts/vault/values.yaml
+++ b/helm_charts/vault/values.yaml
@@ -7,7 +7,7 @@ Consul:
   Cpu: "150m"
   Datacenter: "dc1"
   Image: "consul"
-  ImageTag: "1.5.1"
+  ImageTag: "1.5.3"
   ImagePullPolicy: "IfNotPresent"
   Memory: "320Mi"
   Replicas: 5
@@ -39,7 +39,9 @@ Consul:
     ImageTag: "latest"
     Cpu: "512m"
     Memory: "200Mi"
-    S3URL: "" # {{ .Release.Name }} will get added to the end
+    S3URL: ""
+    AwsAccessKeyId: ""
+    AwsSecretAccessKey: ""
     SleepDuration: 7200 # 2 hours
 
   Restore:
@@ -56,7 +58,7 @@ Vault:
   DataStorage: "consul"  # As data "storage": consul / s3
   awsAccessKey: ""
   awsSecretKey: ""
-  awsBucket: ""
+  awsBucketName: ""
   awsBucketRegion: ""
   # Leave unchanged - if "AES-256" or no encryption at rest.
   awsKmsKeyId: "-" # Options: "-", "alias/aws/s3" or custom KMS key id.
@@ -67,7 +69,7 @@ Vault:
     Enabled: true # If enabled, will use service type ClusterIP
   NodePort: 30825 # Ignored if Ingress.Enabled = true
   Image: "vault"
-  ImageTag: "1.1.2"
+  ImageTag: "1.2.1"
   ImagePullPolicy: "IfNotPresent"
   LogLevel: "info"
   Replicas: 3

--- a/helm_charts/vault/values.yaml
+++ b/helm_charts/vault/values.yaml
@@ -96,6 +96,7 @@ Vault:
   Tls:
     ServerName: "vault.consul"
     AlternateServerNames: "vault-alt.consul" # Comma separated
+    caString: "" # if self-signed
     CertString: ""
     KeyString: ""
     LetsEncrypt:

--- a/helm_charts/vault/values.yaml
+++ b/helm_charts/vault/values.yaml
@@ -7,7 +7,7 @@ Consul:
   Cpu: "150m"
   Datacenter: "dc1"
   Image: "consul"
-  ImageTag: "1.4.4"
+  ImageTag: "1.5.1"
   ImagePullPolicy: "IfNotPresent"
   Memory: "320Mi"
   Replicas: 5
@@ -59,7 +59,7 @@ Vault:
     Enabled: true # If enabled, will use service type ClusterIP
   NodePort: 30825 # Ignored if Ingress.Enabled = true
   Image: "vault"
-  ImageTag: "1.1.0"
+  ImageTag: "1.1.1"
   ImagePullPolicy: "IfNotPresent"
   LogLevel: "info"
   Replicas: 3

--- a/helm_charts/vault/values.yaml
+++ b/helm_charts/vault/values.yaml
@@ -52,6 +52,13 @@ Consul:
 # Vault server configuration
 Vault:
   ComponentName: "vault"
+  # Consul is used as "ha_storage".
+  DataStorage: "consul"  # "storage" options: "consul", "s3".
+  awsAccessKey: ""
+  awsSecretKey: ""
+  awsBucket: ""
+  # Leave unchanged - if "AES-256" or no encryption at rest is used 
+  awsKmsKeyId: "-" # Options: "-", "alias/aws/s3" or custom KMS key id
   AutoUnseal: false
   HttpPort: 8200
   HaForwardingPort: 8201
@@ -59,7 +66,7 @@ Vault:
     Enabled: true # If enabled, will use service type ClusterIP
   NodePort: 30825 # Ignored if Ingress.Enabled = true
   Image: "vault"
-  ImageTag: "1.1.1"
+  ImageTag: "1.1.2"
   ImagePullPolicy: "IfNotPresent"
   LogLevel: "info"
   Replicas: 3

--- a/helm_charts/vault/values.yaml
+++ b/helm_charts/vault/values.yaml
@@ -52,13 +52,14 @@ Consul:
 # Vault server configuration
 Vault:
   ComponentName: "vault"
-  # Consul is used as "ha_storage".
-  DataStorage: "consul"  # "storage" options: "consul", "s3".
+  # As "ha_storage" - Consul.
+  DataStorage: "consul"  # As data "storage": consul / s3
   awsAccessKey: ""
   awsSecretKey: ""
   awsBucket: ""
-  # Leave unchanged - if "AES-256" or no encryption at rest is used 
-  awsKmsKeyId: "-" # Options: "-", "alias/aws/s3" or custom KMS key id
+  awsBucketRegion: ""
+  # Leave unchanged - if "AES-256" or no encryption at rest.
+  awsKmsKeyId: "-" # Options: "-", "alias/aws/s3" or custom KMS key id.
   AutoUnseal: false
   HttpPort: 8200
   HaForwardingPort: 8201

--- a/helm_charts/vault/values.yaml
+++ b/helm_charts/vault/values.yaml
@@ -7,7 +7,7 @@ Consul:
   Cpu: "150m"
   Datacenter: "dc1"
   Image: "consul"
-  ImageTag: "1.5.3"
+  ImageTag: "1.6.0"
   ImagePullPolicy: "IfNotPresent"
   Memory: "320Mi"
   Replicas: 5
@@ -54,22 +54,23 @@ Consul:
 # Vault server configuration
 Vault:
   ComponentName: "vault"
-  # As "ha_storage" - Consul.
-  DataStorage: "consul"  # As data "storage": consul / s3
   awsAccessKey: ""
   awsSecretKey: ""
+  awsRegion: ""
+  # As "ha_storage" - Consul.
+  DataStorage: "consul"  # consul / s3
   awsBucketName: ""
-  awsBucketRegion: ""
-  # Leave unchanged - if "AES-256" or no encryption at rest.
-  awsKmsKeyId: "-" # Options: "-", "alias/aws/s3" or custom KMS key id.
-  AutoUnseal: false
+  awsBucketKmsKeyId: "-" # "alias/aws/s3" or custom KMS key id.
+  AutoUnseal: false # Using K8s secret (deprecated)
+  unsealAwsKmsKey: "-"
+  unsealAwsKmsEndpoint: "-"
   HttpPort: 8200
   HaForwardingPort: 8201
   Ingress:
     Enabled: true # If enabled, will use service type ClusterIP
   NodePort: 30825 # Ignored if Ingress.Enabled = true
   Image: "vault"
-  ImageTag: "1.2.1"
+  ImageTag: "1.2.2"
   ImagePullPolicy: "IfNotPresent"
   LogLevel: "info"
   Replicas: 3


### PR DESCRIPTION
* Add ability to use AWS S3 as Vault's Data Storage ("storage") and Consul only as Vault's High Availability Storage ("ha_storage").
* Add ability to auto-unseal using AWS KMS key
* Add ability to use manually pre-created self-signed certs.
* Address Helm v2.14 New Validation Rules - https://github.com/helm/helm/pull/5576.
* Use "Soft" AntiAffinities to allow deployment to single node services such as microK8s or Minikube.
*  Fix Consul's backup procedure - https://github.com/PremiereGlobal/vault-helm-chart/issues/50.
* Fix Ingress over TLS.
* Bumped Vault to v1.2.2 and Consul to v1.6.0.
* Fix GitHub's Chart URL in `README.md`.